### PR TITLE
Expose deriveSeed and fromSeed as static method

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,20 @@ where loading WASM is sync, or where crypto routines are sync, but everything
 is kept async as a lowest common denominator between browser APIs and future
 hardware wallet support.
 
-### `const wallet = await Wallet.fromMnemonic(mnemonic)`
+### `const wallet = await VegaWallet.fromMnemonic(mnemonic)`
 
-Generate a new `Wallet` from a BIP-0032 mnemonic. Note that the mnemonic
-is not validated before key derivation.
+Derive a new SLIP-10 `VegaWallet` from a BIP-0039 mnemonic. Note that the
+mnemonic is not validated before key derivation.
+
+### `const seed = await VegaWallet.deriveSeed(mnemonic)`
+
+Derive a `seed` from a BIP-0039 mnemonic. In combination with
+`VegaWallet.fromSeed` this is equivalent to `VegaWallet.fromMnemonic`.
+Note that the mnemonic is not validated before key derivation.
+
+### `const wallet = await VegaWallet.fromSeed(seed)`
+
+Derive a new SLIP-10 `VegaWallet` from a `seed`.
 
 ### `const kp = await wallet.keyPair(index)`
 

--- a/lib/hd-wallet.js
+++ b/lib/hd-wallet.js
@@ -70,14 +70,28 @@ export class Wallet {
    * @param  {string} [curve=CURVE_ED25519] - Elliptic Curve
    * @return {Promise<Wallet>}
    */
-  static async fromMnemonic (mnemonic, password = '', curve = CURVE_ED25519) {
-    assert(mnemonic instanceof Uint8Array || typeof mnemonic === 'string')
-    assert(password instanceof Uint8Array || typeof password === 'string')
+  static async fromMnemonic (mnemonic, password, curve = CURVE_ED25519) {
     assert(curve === CURVE_ED25519, 'Only Ed25519 is supported for now')
 
-    const seed = await bip0039.seed(mnemonic, password)
+    const seed = await this.deriveSeed(mnemonic, password)
 
     return this.fromSeed(seed, curve)
+  }
+
+  /**
+   * Helper to derive a BIP-0039 seed from a mnemonic. Not that the mnemonic is
+   * not validated.
+   *
+   * @async
+   * @param  {string | Uint8Array} mnemonic - BIP-0039 space delimited mnemonic
+   * @param  {string | Uint8Array} [password=""] - Optional password
+   * @returns {Promise<Uint8Array>}
+   */
+  static async deriveSeed (mnemonic, password = '') {
+    assert(mnemonic instanceof Uint8Array || typeof mnemonic === 'string')
+    assert(password instanceof Uint8Array || typeof password === 'string')
+
+    return bip0039.seed(mnemonic, password)
   }
 
   /**
@@ -94,6 +108,6 @@ export class Wallet {
 
     const { secretKey, chainCode } = await slip0010.master(seed, curve)
 
-    return new Wallet(secretKey, chainCode)
+    return new this(secretKey, chainCode)
   }
 }

--- a/lib/vega-wallet.js
+++ b/lib/vega-wallet.js
@@ -7,14 +7,36 @@ export { HARDENED, PoW }
 export const SLIP44_VEGA_COINTYPE = 1789
 export const VEGA_DEFAULT_KEYSPACE = 0
 
+export const VEGA_DEFAULT_PATH = [
+  HARDENED + SLIP44_VEGA_COINTYPE,
+  HARDENED + VEGA_DEFAULT_KEYSPACE
+]
+
 export class VegaWallet extends Wallet {
   /**
+   * @async
    * @param {string | Uint8Array} mnemonic
+   * @returns {Promise<VegaWallet>}
    */
   static async fromMnemonic (mnemonic) {
     const master = await super.fromMnemonic(mnemonic)
-    const vega = await master.child(HARDENED + SLIP44_VEGA_COINTYPE)
-    const defaultUsage = await vega.child(HARDENED + VEGA_DEFAULT_KEYSPACE)
+
+    const vega = await master.child(VEGA_DEFAULT_PATH[0])
+    const defaultUsage = await vega.child(VEGA_DEFAULT_PATH[1])
+
+    return defaultUsage
+  }
+
+  /**
+   * @async
+   * @param {Uint8Array} seed
+   * @returns {Promise<VegaWallet>}
+   */
+  static async fromSeed (seed) {
+    const master = await super.fromSeed(seed)
+
+    const vega = await master.child(VEGA_DEFAULT_PATH[0])
+    const defaultUsage = await vega.child(VEGA_DEFAULT_PATH[1])
 
     return defaultUsage
   }

--- a/lib/vega-wallet.js
+++ b/lib/vega-wallet.js
@@ -15,20 +15,6 @@ export const VEGA_DEFAULT_PATH = [
 export class VegaWallet extends Wallet {
   /**
    * @async
-   * @param {string | Uint8Array} mnemonic
-   * @returns {Promise<VegaWallet>}
-   */
-  static async fromMnemonic (mnemonic) {
-    const master = await super.fromMnemonic(mnemonic)
-
-    const vega = await master.child(VEGA_DEFAULT_PATH[0])
-    const defaultUsage = await vega.child(VEGA_DEFAULT_PATH[1])
-
-    return defaultUsage
-  }
-
-  /**
-   * @async
    * @param {Uint8Array} seed
    * @returns {Promise<VegaWallet>}
    */

--- a/test/vega-wallet.js
+++ b/test/vega-wallet.js
@@ -1,0 +1,13 @@
+import { VegaWallet, HARDENED } from '@vegaprotocol/crypto/vega-wallet'
+import test from 'tape'
+
+test('Can recreate wallet from seed', async assert => {
+  const mnemonic = 'foo bar'
+
+  const expected = await VegaWallet.fromMnemonic(mnemonic)
+
+  const seed = await VegaWallet.deriveSeed(mnemonic)
+  const actual = await VegaWallet.fromSeed(seed)
+
+  assert.deepEqual((await expected.keyPair(HARDENED + 1)).pk, (await actual.keyPair(HARDENED + 1)).pk)
+})


### PR DESCRIPTION
This should make it possible to save the seed in encrypted form, and rederive the same wallet as with the original mnemonic